### PR TITLE
Add a newline character

### DIFF
--- a/resources/default.rb
+++ b/resources/default.rb
@@ -16,7 +16,7 @@ action :install do
   end
 
   file "#{new_resource.load_dir}/#{modname}.conf" do
-    content modname
+    content "#{modname}\n"
     notifies :run, 'execute[update-initramfs]'
   end
 


### PR DESCRIPTION
currently `/etc/modules-load.d/modname.conf` files are being written without a newline character.

this causes a problem when `/etc/modules` is written by the modload service, it runs this:

```
if ls /etc/modules-load.d/*.conf > /dev/null 2>&1 ; then cat /etc/modules-load.d/*.conf >> /etc/modules ; fi
```

which ends up writing a `/etc/modules` file that looks like this:
```
# /etc/modules: kernel modules to load at boot time.
#
# This file contains the names of kernel modules that should be loaded
# at boot time, one per line. Lines beginning with "#" are ignored.

# Manage by modload service, any modification will be override. see in /etc/modules-load.d/
rtc
some_modulenamesome_other_modulenamethird_modulenameyet_another_module
```

if you add a newline character to the `/etc/modules-load.d/*.conf` files, `/etc/modules` will be properly formatted.